### PR TITLE
Allow showing all build results in the status bar

### DIFF
--- a/src/main/java/org/codinjutsu/tools/jenkins/JenkinsAppSettings.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/JenkinsAppSettings.java
@@ -161,6 +161,14 @@ public class JenkinsAppSettings implements PersistentStateComponent<JenkinsAppSe
         myState.setUseGreenColor(useGreenColor);
     }
 
+    public boolean isShowAllInStatusbar() {
+        return myState.isShowAllInStatusbar();
+    }
+
+    public void setShowAllInStatusbar(boolean showAllInStatusbar) {
+        myState.setShowAllInStatusbar(showAllInStatusbar);
+    }
+
     @Data
     public static class State {
 
@@ -173,6 +181,7 @@ public class JenkinsAppSettings implements PersistentStateComponent<JenkinsAppSe
         private int numBuildRetries = DEFAULT_BUILD_RETRY;
         private RssSettings rssSettings = new RssSettings();
         private boolean useGreenColor = false;
+        private boolean showAllInStatusbar = false;
     }
 
     @Data

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/BuildStatusAggregator.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/BuildStatusAggregator.java
@@ -60,6 +60,10 @@ public class BuildStatusAggregator implements BuildStatusVisitor {
         return unstableBuilds.get();
     }
 
+    public int getSucceededBuilds() {
+        return succeededBuilds.get();
+    }
+
     public boolean hasNoResults() {
         return sumAll() == 0;
     }

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.form
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.codinjutsu.tools.jenkins.view.ConfigurationPanel">
-  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="rootPanel" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="600" height="600"/>
+      <xy x="20" y="20" width="600" height="625"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -321,7 +321,7 @@
       <grid id="df156" binding="rssStatusFilterPanel" layout-manager="GridLayoutManager" row-count="1" column-count="5" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -368,7 +368,7 @@
       <grid id="a9363" binding="uploadPatchSettingsPanel" layout-manager="GridLayoutManager" row-count="2" column-count="3" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -409,7 +409,7 @@
       <grid id="dab3a" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -421,7 +421,15 @@
           </vspacer>
         </children>
       </grid>
-      <component id="ddc9f" class="javax.swing.JCheckBox" binding="useGreenColor">
+      <component id="ddc9f" class="javax.swing.JCheckBox" binding="showAllInStatusbar">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Show all builds in status bar"/>
+        </properties>
+      </component>
+      <component id="aa62e" class="javax.swing.JCheckBox" binding="useGreenColor">
         <constraints>
           <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.java
@@ -35,12 +35,19 @@ import org.codinjutsu.tools.jenkins.view.validator.NotNullValidator;
 import org.codinjutsu.tools.jenkins.view.validator.PositiveIntegerValidator;
 import org.codinjutsu.tools.jenkins.view.validator.UrlValidator;
 
-import javax.swing.*;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import javax.swing.JRadioButton;
+import javax.swing.JTextField;
+import javax.swing.JTextPane;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
-import java.awt.*;
+import java.awt.Color;
 
 import static org.codinjutsu.tools.jenkins.view.validator.ValidatorTypeEnum.POSITIVE_INTEGER;
 import static org.codinjutsu.tools.jenkins.view.validator.ValidatorTypeEnum.URL;
@@ -80,6 +87,7 @@ public class ConfigurationPanel {
     private JTextField replaceWithSuffix;
     private JRadioButton version1RadioButton;
     private JRadioButton version2RadioButton;
+    private JCheckBox showAllInStatusbar;
     private JCheckBox useGreenColor;
     @GuiField(validators = POSITIVE_INTEGER)
     private JBIntSpinner timeout;
@@ -191,6 +199,7 @@ public class ConfigurationPanel {
                 || abortedCheckBox.isSelected() != jenkinsAppSettings.shouldDisplayAborted();
 
         boolean isUseGreenColor = isUseGreenColor() != jenkinsAppSettings.isUseGreenColor();
+        boolean isShowAllInStatusbar = isShowAllInStatusbar() != jenkinsAppSettings.isShowAllInStatusbar();
 
         return !jenkinsAppSettings.getServerUrl().equals(serverUrl.getText())
                 || jenkinsAppSettings.getBuildDelay() != getBuildDelay()
@@ -200,6 +209,7 @@ public class ConfigurationPanel {
                 || !(jenkinsSettings.getCrumbData().equals(crumbDataField.getText()))
                 || credentialModified
                 || isUseGreenColor
+                || isShowAllInStatusbar
                 || jenkinsSettings.getConnectionTimeout() != getConnectionTimeout()
                 || statusToIgnoreModified || (!jenkinsAppSettings.getSuffix().equals(replaceWithSuffix.getText()));
     }
@@ -225,6 +235,7 @@ public class ConfigurationPanel {
         jenkinsAppSettings.setDisplayAborted(abortedCheckBox.isSelected());
         jenkinsAppSettings.setSuffix(getSuffix());
         jenkinsAppSettings.setUseGreenColor(isUseGreenColor());
+        jenkinsAppSettings.setShowAllInStatusbar(isShowAllInStatusbar());
         jenkinsSettings.setConnectionTimeout(getConnectionTimeout());
 
         if (StringUtils.isNotBlank(username.getText())) {
@@ -252,6 +263,14 @@ public class ConfigurationPanel {
         this.useGreenColor.setSelected(useGreenColor);
     }
 
+    private boolean isShowAllInStatusbar() {
+        return showAllInStatusbar.isSelected();
+    }
+
+    private void setShowAllInStatusbar(boolean useGreenColor) {
+        this.showAllInStatusbar.setSelected(useGreenColor);
+    }
+
     public void loadConfigurationData(JenkinsAppSettings jenkinsAppSettings, JenkinsSettings jenkinsSettings) {
         serverUrl.setText(jenkinsAppSettings.getServerUrl());
         buildDelay.setText(String.valueOf(jenkinsAppSettings.getBuildDelay()));
@@ -275,6 +294,7 @@ public class ConfigurationPanel {
 
         replaceWithSuffix.setText(String.valueOf(jenkinsAppSettings.getSuffix()));
         setUseGreenColor(jenkinsAppSettings.isUseGreenColor());
+        setShowAllInStatusbar(jenkinsAppSettings.isShowAllInStatusbar());
         timeout.setNumber(jenkinsSettings.getConnectionTimeout());
 
         if (jenkinsSettings.getVersion().equals(JenkinsVersion.VERSION_1)) {

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/JenkinsWidget.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/JenkinsWidget.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.components.panels.NonOpaquePanel;
 import org.codinjutsu.tools.jenkins.BuildStatusSummaryFactory;
+import org.codinjutsu.tools.jenkins.JenkinsAppSettings;
 import org.codinjutsu.tools.jenkins.JenkinsToolWindowFactory;
 import org.codinjutsu.tools.jenkins.logic.BuildStatusAggregator;
 import org.codinjutsu.tools.jenkins.view.util.BuildStatusIcon;
@@ -42,6 +43,7 @@ import java.awt.event.MouseEvent;
 public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidget {
 
     private final Project project;
+    private final JenkinsAppSettings jenkinsAppSettings;
 
     public static JenkinsWidget getInstance(Project project) {
         return ServiceManager.getService(project, JenkinsWidget.class);
@@ -49,6 +51,8 @@ public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidg
 
     public JenkinsWidget(Project project) {
         this.project = project;
+        jenkinsAppSettings = JenkinsAppSettings.getSafeInstance(project);
+
         JComponent buildStatusIcon = createStatusIcon(new BuildStatusAggregator());
         setLayout(new BorderLayout());
         add(buildStatusIcon, BorderLayout.CENTER);
@@ -67,7 +71,7 @@ public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidg
     }
 
     private JComponent createStatusIcon(BuildStatusAggregator aggregator) {
-        JComponent statusIcon = BuildStatusIcon.createIcon(aggregator, BuildStatusEnumRenderer.getInstance(project));
+        JComponent statusIcon = BuildStatusIcon.createIcon(jenkinsAppSettings.isShowAllInStatusbar(), aggregator, BuildStatusEnumRenderer.getInstance(project));
         statusIcon.addMouseListener(new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/JenkinsWidget.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/JenkinsWidget.java
@@ -32,10 +32,11 @@ import org.codinjutsu.tools.jenkins.view.util.BuildStatusIcon;
 import org.codinjutsu.tools.jenkins.view.util.WidgetBorderUtil;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
-import java.awt.*;
+import javax.swing.JComponent;
+import java.awt.BorderLayout;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
+import java.util.stream.Stream;
 
 /**
  * Jenkins status bar widget
@@ -72,7 +73,7 @@ public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidg
 
     private JComponent createStatusIcon(BuildStatusAggregator aggregator) {
         JComponent statusIcon = BuildStatusIcon.createIcon(jenkinsAppSettings.isShowAllInStatusbar(), aggregator, BuildStatusEnumRenderer.getInstance(project));
-        statusIcon.addMouseListener(new MouseAdapter() {
+        MouseAdapter adapter = new MouseAdapter() {
             @Override
             public void mousePressed(MouseEvent e) {
                 activateBrowserToolWindow();
@@ -82,7 +83,8 @@ public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidg
             public void mouseReleased(MouseEvent e) {
                 activateBrowserToolWindow();
             }
-        });
+        };
+        Stream.concat(Stream.of(statusIcon.getComponents()), Stream.of(statusIcon)).forEach(c -> c.addMouseListener(adapter));
 
         setBorder(WidgetBorderUtil.getBorderInstance());
 
@@ -99,15 +101,19 @@ public class JenkinsWidget extends NonOpaquePanel implements CustomStatusBarWidg
         toolWindow.activate(null);
     }
 
+    @Override
     @NotNull
     public String ID() {
         return BuildStatusSummaryFactory.BUILD_STATUS_SUMMARY_ID;
     }
 
+    @Override
     public void install(@NotNull StatusBar statusBar) {}
 
+    @Override
     public void dispose() {}
 
+    @Override
     public JComponent getComponent() {
         return this;
     }

--- a/src/test/java/org/codinjutsu/tools/jenkins/view/util/BuildStatusIconTest.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/view/util/BuildStatusIconTest.java
@@ -37,7 +37,7 @@ public class BuildStatusIconTest {
     public void noBuildsShouldDisplayGreyIcon() {
         Mockito.when(aggregatorMock.hasNoResults()).thenReturn(true);
 
-        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(aggregatorMock, buildStatusRenderer);
+        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(false, aggregatorMock, buildStatusRenderer);
         assertIconEquals("grey.svg", statusIcon.icon);
         assertEquals("No builds", statusIcon.toolTipText);
         assertEquals(0, statusIcon.numberToDisplay);
@@ -49,7 +49,7 @@ public class BuildStatusIconTest {
         Mockito.when(aggregatorMock.getBrokenBuilds()).thenReturn(4);
         Mockito.when(aggregatorMock.getUnstableBuilds()).thenReturn(2);
 
-        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(aggregatorMock, buildStatusRenderer);
+        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(false, aggregatorMock, buildStatusRenderer);
         assertIconEquals("red.svg", statusIcon.icon);
         assertEquals("4 broken builds", statusIcon.toolTipText);
         assertEquals(4, statusIcon.numberToDisplay);
@@ -61,7 +61,7 @@ public class BuildStatusIconTest {
         Mockito.when(aggregatorMock.getBrokenBuilds()).thenReturn(0);
         Mockito.when(aggregatorMock.getUnstableBuilds()).thenReturn(2);
 
-        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(aggregatorMock, buildStatusRenderer);
+        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(false, aggregatorMock, buildStatusRenderer);
         assertIconEquals("yellow.svg", statusIcon.icon);
         assertEquals("2 unstable builds", statusIcon.toolTipText);
         assertEquals(2, statusIcon.numberToDisplay);
@@ -73,10 +73,33 @@ public class BuildStatusIconTest {
         Mockito.when(aggregatorMock.getBrokenBuilds()).thenReturn(0);
         Mockito.when(aggregatorMock.getUnstableBuilds()).thenReturn(0);
 
-        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(aggregatorMock, buildStatusRenderer);
+        BuildStatusIcon statusIcon = (BuildStatusIcon) BuildStatusIcon.createIcon(false, aggregatorMock, buildStatusRenderer);
         assertIconEquals("blue.svg", statusIcon.icon);
         assertEquals("No broken builds", statusIcon.toolTipText);
         assertEquals(0, statusIcon.numberToDisplay);
+    }
+
+    @Test
+    public void combineIcons() {
+        Mockito.when(aggregatorMock.hasNoResults()).thenReturn(false);
+        Mockito.when(aggregatorMock.getBrokenBuilds()).thenReturn(1);
+        Mockito.when(aggregatorMock.getUnstableBuilds()).thenReturn(2);
+        Mockito.when(aggregatorMock.getSucceededBuilds()).thenReturn(3);
+
+        JPanel statusIcons = (JPanel) BuildStatusIcon.createIcon(true, aggregatorMock, buildStatusRenderer);
+        assertEquals(3, statusIcons.getComponents().length);
+
+        assertIconEquals("red.svg", ((BuildStatusIcon) statusIcons.getComponents()[0]).icon);
+        assertEquals("1 broken builds", ((BuildStatusIcon) statusIcons.getComponents()[0]).toolTipText);
+        assertEquals(1, ((BuildStatusIcon) statusIcons.getComponents()[0]).numberToDisplay);
+
+        assertIconEquals("yellow.svg", ((BuildStatusIcon) statusIcons.getComponents()[1]).icon);
+        assertEquals("2 unstable builds", ((BuildStatusIcon) statusIcons.getComponents()[1]).toolTipText);
+        assertEquals(2, ((BuildStatusIcon) statusIcons.getComponents()[1]).numberToDisplay);
+
+        assertIconEquals("blue.svg", ((BuildStatusIcon) statusIcons.getComponents()[2]).icon);
+        assertEquals("3 succeeded builds", ((BuildStatusIcon) statusIcons.getComponents()[2]).toolTipText);
+        assertEquals(3, ((BuildStatusIcon) statusIcons.getComponents()[2]).numberToDisplay);
     }
 
     private void assertIconEquals(String expectedIconFilename, Icon actualIcon) {


### PR DESCRIPTION
When working in a team it can be useful to see the status of all builds instead of just the highest prio ones.