### PR TITLE
Remove password validation

### DIFF
--- a/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.java
@@ -148,15 +148,8 @@ public class ConfigurationPanel {
 
         testConnectionButton.addActionListener(event -> testConnection(project));
 
-        formValidator = FormValidator.<JTextField>init(this)
-                .addValidator(username, component -> {
-                    if (StringUtils.isNotBlank(component.getText())) {
-                        String password = getPassword();
-                        if (StringUtils.isBlank(password)) {
-                            throw new ConfigurationException(String.format("'%s' must be set", passwordField.getName()));
-                        }
-                    }
-                });
+        formValidator = FormValidator.<JTextField>init(this);
+                
     }
 
     private void testConnection(Project project) {


### PR DESCRIPTION
In my company we dont' use username/passwords, instead we're using tokens for identification. Therefore, only the username is useful, but your plugin insists on having a password. Can we remove that? thanks.