### PR TITLE
fixes #230:  jobs in folders: job name too long

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,10 @@
 Version 0.13.7
     * #232 PersistentStringParameter not supported
-    * #234 Can't seem to connect to my jenkins server with the latest version 0.13.6-2020.1
     * #233 Error overlay over whole of screen if connection is lost. Add Notification group to configure the behaviour in IDE settings.
+    * #234 Can't seem to connect to my jenkins server with the latest version 0.13.6-2020.1
+    * Add Notification group to configure the behaviour in IDE settings.
+    * Fix: regression: remove trailing Slash for URL Validation
+    * #230: jobs in folders: job name too long
 
 Version 0.13.6
     * #225 Git Branch Parameter is unsupported

--- a/includes/pluginChanges.html
+++ b/includes/pluginChanges.html
@@ -6,6 +6,7 @@
     <li>#233 Error overlay over whole of screen if connection is lost.<br>
         Add Notification group to configure the behaviour in IDE settings.
     </li>
+    <li>#230: jobs in folders: job name too long</li>
 </ul>
 <h3>0.13.6</h3>
 <ul>

--- a/src/main/java/org/codinjutsu/tools/jenkins/TraceableBuildJob.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/TraceableBuildJob.java
@@ -52,7 +52,7 @@ public class TraceableBuildJob implements Runnable {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(job.getName(), job.getUrl());
+        return Objects.hashCode(job.getNameToRenderSingleJob(), job.getUrl());
     }
 
     @Override

--- a/src/main/java/org/codinjutsu/tools/jenkins/exception/NoJobFoundException.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/exception/NoJobFoundException.java
@@ -42,11 +42,11 @@ public class NoJobFoundException extends RuntimeException {
     @NotNull
     private static String createMessage(@NotNull Job job, @Nullable String cause) {
         return MessageFormat.format("Could not find Job data for: {0} [{1}].\nCause: {2}",
-                job.getName(), job.getUrl(), cause);
+                job.getNameToRenderSingleJob(), job.getUrl(), cause);
     }
 
     @NotNull
     private static String createMessage(@NotNull Job job) {
-        return MessageFormat.format("Could not find Job data for: {0} [{1}]", job.getName(), job.getUrl());
+        return MessageFormat.format("Could not find Job data for: {0} [{1}]", job.getNameToRenderSingleJob(), job.getUrl());
     }
 }

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParser.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParser.java
@@ -215,14 +215,17 @@ public class JenkinsJsonParser implements JenkinsParser {
         final String fullName = jsonObject.getStringOrDefault(createJsonKey(JOB_FULL_NAME, name));
         final JobType jobType = getJobType(jsonObject);
         final String displayName = getDisplayName(jsonObject);
+        final String fullDisplayName = getFullDisplayName(jsonObject);
         final String url = jsonObject.getString(createJsonKey(JOB_URL));
         final String color = jsonObject.getStringOrDefault(createJsonKey(JOB_COLOR, null));
         final boolean buildable = getBoolean(jsonObject.getBoolean(createJsonKey(JOB_IS_BUILDABLE)));
         final boolean inQueue = getBoolean(jsonObject.getBoolean(createJsonKey(JOB_IS_IN_QUEUE)));
 
         JsonArray healths = (JsonArray) jsonObject.get(JOB_HEALTH);
-        final Job.JobBuilder jobBuilder = Job.builder().name(name).jobType(jobType).displayName(displayName)
-                .fullName(fullName).color(color).url(url).inQueue(inQueue).buildable(buildable)
+        final Job.JobBuilder jobBuilder = Job.builder().name(name).jobType(jobType)
+                .fullName(fullName)
+                .displayName(displayName).fullDisplayName(fullDisplayName)
+                .color(color).url(url).inQueue(inQueue).buildable(buildable)
                 .health(getHealth(healths));
 
         JsonObject lastBuildObject = (JsonObject) jsonObject.get(JOB_LAST_BUILD);
@@ -234,9 +237,12 @@ public class JenkinsJsonParser implements JenkinsParser {
 
     @Nullable
     private String getDisplayName(@NotNull JsonObject jsonObject) {
-        final JsonKey preferFullDisplayName = createJsonKey(JOB_FULL_DISPLAY_NAME,
-                jsonObject.getString(createJsonKey(JOB_DISPLAY_NAME)));
-        return jsonObject.getStringOrDefault(preferFullDisplayName);
+        return jsonObject.getStringOrDefault(createJsonKey(JOB_DISPLAY_NAME));
+    }
+
+    @Nullable
+    private String getFullDisplayName(@NotNull JsonObject jsonObject) {
+        return jsonObject.getStringOrDefault(createJsonKey(JOB_FULL_DISPLAY_NAME));
     }
 
     @NotNull

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/RequestManager.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/RequestManager.java
@@ -360,7 +360,7 @@ public class RequestManager implements RequestManagerInterface {
             return lastCompletedBuild.equals(com.offbytwo.jenkins.model.Build.BUILD_HAS_NEVER_RUN) ? null :
                     lastCompletedBuild.details().getConsoleOutputText();
         } catch (IOException e) {
-            logger.warn("cannot load log for " + job.getName());
+            logger.warn("cannot load log for " + job.getNameToRenderSingleJob());
             return null;
         }
     }
@@ -380,7 +380,7 @@ public class RequestManager implements RequestManagerInterface {
             }
             return result;
         } catch (IOException e) {
-            logger.warn("cannot load test results for " + job.getName());
+            logger.warn("cannot load test results for " + job.getNameToRenderSingleJob());
             return Collections.emptyList();
         }
     }

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/RunBuildWithPatch.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/RunBuildWithPatch.java
@@ -47,7 +47,7 @@ public final class RunBuildWithPatch {
                          @NotNull Consumer<String> errorNotifier) {
         if (!job.hasParameter(RunBuildWithPatch.PARAMETER_NAME)) {
             errorNotifier.accept(String.format("Job \"%s\" should has parameter with name \"%s\"",
-                    job.getName(), RunBuildWithPatch.PARAMETER_NAME));
+                    job.getNameToRenderSingleJob(), RunBuildWithPatch.PARAMETER_NAME));
         }
         try {
             final JenkinsAppSettings settings = JenkinsAppSettings.getSafeInstance(project);
@@ -70,7 +70,7 @@ public final class RunBuildWithPatch {
     VirtualFile prepareFile(BrowserPanel browserPanel, @NotNull VirtualFile file,
                             JenkinsAppSettings settings, Job job) throws IOException {
         if (file.exists()) {
-            final String suffix = settings.getSuffix().replace(SUFFIX_JOB_NAME_MACROS, job.getName());
+            final String suffix = settings.getSuffix().replace(SUFFIX_JOB_NAME_MACROS, job.getNameToRenderSingleJob());
             final String preparedContent = prepareFileContent(file, suffix);
 
             WriteAction.run(() -> {
@@ -156,7 +156,7 @@ public final class RunBuildWithPatch {
 
         private void notifyOnGoingMessage(Job job) {
             browserPanel.notifyInfoJenkinsToolWindow(HtmlUtil.createHtmlLinkMessage(
-                    job.getName() + " build is on going", job.getUrl()));
+                    job.getNameToRenderSingleJob() + " build is on going", job.getUrl()));
         }
     }
 }

--- a/src/main/java/org/codinjutsu/tools/jenkins/model/Job.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/model/Job.java
@@ -28,10 +28,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * TODO mcmics: use {@link Value}
@@ -62,6 +60,9 @@ public class Job {
     @Builder.Default
     @Nullable
     private final String displayName = null;
+    @Builder.Default
+    @Nullable
+    private final String fullDisplayName = null;
     @NotNull
     private final String fullName;
     @NotNull
@@ -111,11 +112,15 @@ public class Job {
     }
 
     @NotNull
-    public String getName() {
-        if (StringUtils.isEmpty(displayName)) {
-            return name;
-        }
-        return displayName;
+    public String getNameToRenderSingleJob() {
+        return Optional.ofNullable(getFullDisplayName()).filter(Predicate.not(StringUtils::isEmpty))
+                .orElseGet(this::preferDisplayName);
+    }
+
+    @NotNull
+    public String preferDisplayName() {
+        return Optional.ofNullable(getDisplayName()).filter(Predicate.not(StringUtils::isEmpty))
+                .orElseGet(this::getName);
     }
 
     public boolean hasParameters() {

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/BrowserPanel.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/BrowserPanel.java
@@ -69,7 +69,7 @@ public class BrowserPanel extends SimpleToolWindowPanel {
     private static final String LOADING = "Loading...";
     private static final JobNameComparator JOB_NAME_COMPARATOR = new JobNameComparator();
     private static final Comparator<Job> sortByStatusComparator = Comparator.comparing(BrowserPanel::toBuildStatus);
-    private static final Comparator<Job> sortByNameComparator = Comparator.comparing(Job::getName, JOB_NAME_COMPARATOR);
+    private static final Comparator<Job> sortByNameComparator = Comparator.comparing(Job::getNameToRenderSingleJob, JOB_NAME_COMPARATOR);
     private final Tree jobTree;
     private final Runnable refreshViewJob;
     private final Project project;
@@ -236,7 +236,7 @@ public class BrowserPanel extends SimpleToolWindowPanel {
 
     @NotNull
     public Optional<Job> getJob(String name) {
-        return getAllJobs().stream().filter(job -> job.getName().equals(name)).findFirst();
+        return getAllJobs().stream().filter(job -> job.getNameToRenderSingleJob().equals(name)).findFirst();
     }
 
     public void setSortedByStatus(boolean sortedByBuildStatus) {
@@ -352,7 +352,7 @@ public class BrowserPanel extends SimpleToolWindowPanel {
             final DefaultMutableTreeNode node = (DefaultMutableTreeNode) treePath.getLastPathComponent();
             final Object userObject = node.getUserObject();
             if (userObject instanceof Job) {
-                return ((Job) userObject).getName();
+                return ((Job) userObject).getNameToRenderSingleJob();
             }
             return "<empty>";
         });
@@ -539,14 +539,12 @@ public class BrowserPanel extends SimpleToolWindowPanel {
     }
 
     public void addToWatch(String changeListName, Job job) {
-        JenkinsAppSettings settings = JenkinsAppSettings.getSafeInstance(project);
-
         final Build lastBuild = job.getLastBuild();
         if (lastBuild != null) {
             final int nextBuildNumber = lastBuild.getNumber() + 1;
             final Build nextBuild = lastBuild.toBuilder()
                     .number(nextBuildNumber)
-                    .url(settings.getServerUrl() + String.format("/job/%s/%d/", job.getName(), nextBuildNumber))
+                    .url(String.format("%s/%d/", job.getUrl(), nextBuildNumber))
                     .build();
             job.setLastBuild(nextBuild);
         }

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/SelectJobDialog.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/SelectJobDialog.java
@@ -107,7 +107,7 @@ public class SelectJobDialog extends JDialog {
         final DefaultComboBoxModel<String> jobListModel = new DefaultComboBoxModel<>();
         jobs.stream().filter(Job::hasParameters)
                 .filter(job -> job.hasParameter(RunBuildWithPatch.PARAMETER_NAME))
-                .map(Job::getName)
+                .map(Job::getNameToRenderSingleJob)
                 .forEach(jobListModel::addElement);
         jobsList.setModel(jobListModel);
     }

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/action/RunBuildAction.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/action/RunBuildAction.java
@@ -75,7 +75,7 @@ public class RunBuildAction extends AnAction implements DumbAware {
 
     private void notifyOnGoingMessage(BrowserPanel browserPanel, Job job) {
         browserPanel.notifyInfoJenkinsToolWindow(HtmlUtil.createHtmlLinkMessage(
-                job.getName() + " build is on going",
+                job.getNameToRenderSingleJob() + " build is on going",
                 job.getUrl()));
     }
 
@@ -85,7 +85,7 @@ public class RunBuildAction extends AnAction implements DumbAware {
             @Override
             public void onSuccess() {
                 ExecutorService.getInstance(project).getExecutor().schedule(() -> GuiUtil.runInSwingThread(() -> {
-                    final Optional<Job> newJob = browserPanel.getJob(job.getName());
+                    final Optional<Job> newJob = browserPanel.getJob(job.getNameToRenderSingleJob());
                     newJob.ifPresent(browserPanel::loadJob);
                 }), BUILD_STATUS_UPDATE_DELAY, TimeUnit.SECONDS);
             }
@@ -103,7 +103,7 @@ public class RunBuildAction extends AnAction implements DumbAware {
                         }
 
                         public void notifyOnError(Job job, Throwable ex) {
-                            browserPanel.notifyErrorJenkinsToolWindow("Build '" + job.getName() + "' cannot be run: " + ex.getMessage());
+                            browserPanel.notifyErrorJenkinsToolWindow("Build '" + job.getNameToRenderSingleJob() + "' cannot be run: " + ex.getMessage());
                             browserPanel.loadJob(job);
                         }
 

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/action/ShowLogAction.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/action/ShowLogAction.java
@@ -57,7 +57,7 @@ public class ShowLogAction extends AnAction implements DumbAware {
         final BrowserPanel browserPanelForAction = ActionUtil.getBrowserPanel(event);
 
         final Job job = browserPanelForAction.getSelectedJob();
-        new Task.Backgroundable(project, job.getName(), false) {
+        new Task.Backgroundable(project, job.getNameToRenderSingleJob(), false) {
 
             String consoleContent;
 

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/action/UploadPatchToJobAction.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/action/UploadPatchToJobAction.java
@@ -71,7 +71,7 @@ public class UploadPatchToJobAction extends AnAction implements DumbAware {
                             ModalityState.NON_MODAL);
                 }
             } else {
-                message = String.format("Job \"%s\" should has parameter with name \"%s\"", job.getName(),
+                message = String.format("Job \"%s\" should has parameter with name \"%s\"", job.getNameToRenderSingleJob(),
                         RunBuildWithPatch.PARAMETER_NAME);
             }
 

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/action/results/JobTestResultsToolWindow.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/action/results/JobTestResultsToolWindow.java
@@ -65,7 +65,7 @@ public class JobTestResultsToolWindow {
         } catch (ExecutionException e) {
             throw new RuntimeException(e);
         }
-        showInToolWindow(consoleView, job.getName());
+        showInToolWindow(consoleView, job.getNameToRenderSingleJob());
         processHandler.startNotify();
     }
 

--- a/src/test/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParserTest.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParserTest.java
@@ -222,6 +222,19 @@ public class JenkinsJsonParserTest {
         Job actualJob = jsonParser.createJob(IOUtils.toString(getClass().getResourceAsStream("JsonRequestManager_loadJob.json")));
         final Job expectedJob = new JobBuilder()
                 .job("config-provider-model", "blue", "http://ci.jenkins-ci.org/job/config-provider-model/", false, true)
+                .fullDisplayName("config-provider-model")
+                .lastBuild("http://ci.jenkins-ci.org/job/config-provider-model/8/", 8, "SUCCESS", false, "2012-04-02_16-26-29", 1477640156281l, 4386421l)
+                .health("health-80plus", "0 tests en echec sur un total de 24 tests")
+                .get();
+        assertThat(actualJob).isEqualTo(expectedJob);
+    }
+
+    @Test
+    public void testLoadJobWithFullDisplayName() throws Exception {
+        Job actualJob = jsonParser.createJob(IOUtils.toString(getClass().getResourceAsStream("JsonRequestManager_loadJobWithFullDisplayName.json")));
+        final Job expectedJob = new JobBuilder()
+                .job("config-provider-model", "blue", "http://ci.jenkins-ci.org/job/config-provider-model/", false, true)
+                .fullDisplayName("config-provider-model-full")
                 .lastBuild("http://ci.jenkins-ci.org/job/config-provider-model/8/", 8, "SUCCESS", false, "2012-04-02_16-26-29", 1477640156281l, 4386421l)
                 .health("health-80plus", "0 tests en echec sur un total de 24 tests")
                 .get();
@@ -246,8 +259,9 @@ public class JenkinsJsonParserTest {
                 .job("Simple Jenkins Test", "yellow", "http://localhost:8080/job/Simple%20Jenkins%20Test/", false, true)
                 .lastBuild(lastBuild)
                 .health("health-40to59", "Testergebnis: 1 Test von 2 Tests fehlgeschlagen.")
-                .displayName("Parent -> Simple Jenkins Test")
+                .displayName("Simple Jenkins Test")
                 .fullName("Parent/Simple Jenkins Test")
+                .fullDisplayName("Parent -> Simple Jenkins Test")
                 .get();
         assertThat(actualJob).isEqualTo(expected);
     }

--- a/src/test/java/org/codinjutsu/tools/jenkins/logic/JobBuilder.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/logic/JobBuilder.java
@@ -32,6 +32,7 @@ public class JobBuilder {
         jobBuilder.name(jobName).color(jobColor).url(jobUrl).inQueue(inQueue).buildable(buildable);
         jobBuilder.displayName(jobName);
         jobBuilder.fullName(jobName);
+        //jobBuilder.fullDisplayName(jobName);
         return this;
     }
 
@@ -42,6 +43,11 @@ public class JobBuilder {
 
     public JobBuilder fullName(@NotNull String fullName) {
         jobBuilder.fullName(fullName);
+        return this;
+    }
+
+    public JobBuilder fullDisplayName(@NotNull String fullDisplayName) {
+        jobBuilder.fullDisplayName(fullDisplayName);
         return this;
     }
 

--- a/src/test/java/org/codinjutsu/tools/jenkins/model/JobTest.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/model/JobTest.java
@@ -1,0 +1,59 @@
+package org.codinjutsu.tools.jenkins.model;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class JobTest {
+
+    @Test
+    public void getNameToRenderSingleJob() {
+        final Job withName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .build();
+        final Job withDisplayName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .displayName("Job Display Name")
+                .build();
+        final Job withFullDisplayName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .displayName("Job Display Name")
+                .fullDisplayName("Full Job Display Name")
+                .build();
+        final Job withEmptyFullDisplayName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .displayName("Job Display Name")
+                .fullDisplayName("")
+                .build();
+
+        Assertions.assertThat(withName.getNameToRenderSingleJob()).isEqualTo(withName.getName());
+        Assertions.assertThat(withDisplayName.getNameToRenderSingleJob()).isEqualTo(withDisplayName.getDisplayName());
+        Assertions.assertThat(withFullDisplayName.getNameToRenderSingleJob()).isEqualTo(withFullDisplayName.getFullDisplayName());
+        Assertions.assertThat(withEmptyFullDisplayName.getNameToRenderSingleJob()).isEqualTo(withEmptyFullDisplayName.getDisplayName());
+    }
+
+    @Test
+    public void preferDisplayName() {
+        final Job withName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .build();
+        final Job withDisplayName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .displayName("Job Display Name")
+                .build();
+        final Job withFullDisplayName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .displayName("Job Display Name")
+                .fullDisplayName("Full Job Display Name")
+                .build();
+        final Job withEmptyFullDisplayName = Job.builder().url("http://url").name("Job Name")
+                .fullName("Full Job Name")
+                .displayName("Job Display Name")
+                .fullDisplayName("")
+                .build();
+
+        Assertions.assertThat(withName.preferDisplayName()).isEqualTo(withName.getName());
+        Assertions.assertThat(withDisplayName.preferDisplayName()).isEqualTo(withDisplayName.getDisplayName());
+        Assertions.assertThat(withFullDisplayName.preferDisplayName()).isEqualTo(withFullDisplayName.getDisplayName());
+        Assertions.assertThat(withEmptyFullDisplayName.preferDisplayName()).isEqualTo(withEmptyFullDisplayName.getDisplayName());
+    }
+}

--- a/src/test/resources/org/codinjutsu/tools/jenkins/logic/JsonRequestManager_loadJobWithFullDisplayName.json
+++ b/src/test/resources/org/codinjutsu/tools/jenkins/logic/JsonRequestManager_loadJobWithFullDisplayName.json
@@ -1,7 +1,7 @@
 {
     "name":"config-provider-model",
     "displayName":"config-provider-model",
-    "fullDisplayName":"config-provider-model",
+    "fullDisplayName":"config-provider-model-full",
     "url":"http://ci.jenkins-ci.org/job/config-provider-model/",
     "color":"blue",
     "healthReport":[


### PR DESCRIPTION
change Rendering to use full Displayname only if no Job is Parent of current node