### PR TITLE
Fix Encoding query parameters which cause 'URL is malformed' error for valid Urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 - \#415 Unable to enter parameters
 - Show error for trigger builds (Read from Header X-Error)
 - \#413 0.13.15-2022.2 - still not working with Intellij 2022.3
-  - Fix Proxy Handling 
+  - Fix Proxy Handling
+- \#426 Plugin Failing After IntelliJ Upgrade to 0.13.15 if jenkins is hosted Tomcat or QUery Parameters are not relaxed
+- Add Trace Logging for Url calls with `#org.codinjutsu.tools.jenkins:trace`
 
 ## [0.13.15-2]
 - \#413 0.13.15-2022.2 - still not working with Intellij 2022.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Jenkins Plugin 0.13.15 for Jetbrains products
+# Jenkins Plugin 0.13.16 for Jetbrains products
 [![Build Status](https://app.travis-ci.com/MCMicS/jenkins-control-plugin.svg?branch=master)](https://app.travis-ci.com/MCMicS/jenkins-control-plugin)
 [![Plugin Compatibility](https://github.com/MCMicS/jenkins-control-plugin/actions/workflows/compatibility.yml/badge.svg)](https://github.com/MCMicS/jenkins-control-plugin/actions/workflows/compatibility.yml)
 
@@ -19,7 +19,7 @@
 
 ### Current Release
 * [Idea 2021.2 - 2022.1.4](../../releases/latest/download/jenkins-control-plugin-2021.2.zip)
-* [Idea 2022.2 or newer](../../releases/download/v0.13.15-2/jenkins-control-plugin-2022.2.zip)
+* [Idea 2022.2 or newer](../../releases/latest/download/jenkins-control-plugin-2022.2.zip)
 
 [//]: # (* [Idea 2022.2 or newer]&#40;../../releases/latest/download/jenkins-control-plugin-2022.2.zip&#41;)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = org.codinjutsu
 pluginName = jenkins-control-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 0.13.16-eap2
+pluginVersion = 0.13.16-eap3
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParser.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParser.java
@@ -63,7 +63,7 @@ public class JenkinsJsonParser implements JenkinsParser {
         final JsonObject jsonObject = parseJson(jsonData);
         final Optional<View> primaryView = Optional.ofNullable((JsonObject) jsonObject.get(PRIMARY_VIEW)).map(this::getView);
 
-        final String description = jsonObject.getStringOrDefault(createJsonKey(SERVER_DESCRIPTION, ""));
+        final String description = getStringOrDefaultForNull(jsonObject, SERVER_DESCRIPTION, StringUtils.EMPTY);
         final String jenkinsUrl = getServerUrl(jsonObject);
         final Jenkins jenkins = new Jenkins(description, jenkinsUrl);
         primaryView.ifPresent(jenkins::setPrimaryView);
@@ -266,12 +266,12 @@ public class JenkinsJsonParser implements JenkinsParser {
     @NotNull
     private Job getJob(JsonObject jsonObject) {
         final String name = jsonObject.getString(createJsonKey(JOB_NAME));
-        final String fullName = jsonObject.getStringOrDefault(createJsonKey(JOB_FULL_NAME, name));
+        final String fullName = getStringOrDefaultForNull(jsonObject, JOB_FULL_NAME, name);
         final JobType jobType = getJobType(jsonObject);
         final String displayName = getDisplayName(jsonObject);
         final String fullDisplayName = getFullDisplayName(jsonObject);
         final String url = jsonObject.getString(createJsonKey(JOB_URL));
-        final String color = jsonObject.getStringOrDefault(createJsonKey(JOB_COLOR, null));
+        final String color = getStringOrDefaultForNull(jsonObject, JOB_COLOR, null);
         final boolean buildable = getBoolean(jsonObject.getBoolean(createJsonKey(JOB_IS_BUILDABLE)));
         final boolean inQueue = getBoolean(jsonObject.getBoolean(createJsonKey(JOB_IS_IN_QUEUE)));
 
@@ -484,8 +484,8 @@ public class JenkinsJsonParser implements JenkinsParser {
     @NotNull
     private String getServerUrl(JsonObject jsonObject) {
         final Optional<View> primaryView = Optional.ofNullable((JsonObject) jsonObject.get(PRIMARY_VIEW)).map(this::getView);
-        final String primaryViewUrl = primaryView.map(View::getUrl).orElse("");
-        return Optional.ofNullable(jsonObject.getStringOrDefault(createJsonKey(SERVER_URL, primaryViewUrl))).orElse(StringUtils.EMPTY);
+        final String primaryViewUrl = primaryView.map(View::getUrl).orElse(StringUtils.EMPTY);
+        return getStringOrDefaultForNull(jsonObject, SERVER_URL, primaryViewUrl);
     }
 
     @NotNull
@@ -527,5 +527,10 @@ public class JenkinsJsonParser implements JenkinsParser {
             LOG.error(message);
             throw new JenkinsPluginRuntimeException(message);
         }
+    }
+
+    private @Nullable String getStringOrDefaultForNull(JsonObject jsonObject, @NotNull String key,
+                                                       @Nullable String defaultValue) {
+        return Optional.ofNullable(jsonObject.getStringOrDefault(createJsonKey(key, defaultValue))).orElse(defaultValue);
     }
 }

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParser.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParser.java
@@ -63,7 +63,7 @@ public class JenkinsJsonParser implements JenkinsParser {
         final JsonObject jsonObject = parseJson(jsonData);
         final Optional<View> primaryView = Optional.ofNullable((JsonObject) jsonObject.get(PRIMARY_VIEW)).map(this::getView);
 
-        final String description = getStringOrDefaultForNull(jsonObject, SERVER_DESCRIPTION, StringUtils.EMPTY);
+        final String description = getNonNullStringOrDefaultForNull(jsonObject, SERVER_DESCRIPTION, StringUtils.EMPTY);
         final String jenkinsUrl = getServerUrl(jsonObject);
         final Jenkins jenkins = new Jenkins(description, jenkinsUrl);
         primaryView.ifPresent(jenkins::setPrimaryView);
@@ -265,8 +265,8 @@ public class JenkinsJsonParser implements JenkinsParser {
 
     @NotNull
     private Job getJob(JsonObject jsonObject) {
-        final String name = jsonObject.getString(createJsonKey(JOB_NAME));
-        final String fullName = getStringOrDefaultForNull(jsonObject, JOB_FULL_NAME, name);
+        final String name = getStringNonNull(jsonObject, JOB_NAME);
+        final String fullName = getNonNullStringOrDefaultForNull(jsonObject, JOB_FULL_NAME, name);
         final JobType jobType = getJobType(jsonObject);
         final String displayName = getDisplayName(jsonObject);
         final String fullDisplayName = getFullDisplayName(jsonObject);
@@ -481,11 +481,10 @@ public class JenkinsJsonParser implements JenkinsParser {
         return values;
     }
 
-    @NotNull
-    private String getServerUrl(JsonObject jsonObject) {
+    private @NotNull String getServerUrl(JsonObject jsonObject) {
         final Optional<View> primaryView = Optional.ofNullable((JsonObject) jsonObject.get(PRIMARY_VIEW)).map(this::getView);
         final String primaryViewUrl = primaryView.map(View::getUrl).orElse(StringUtils.EMPTY);
-        return getStringOrDefaultForNull(jsonObject, SERVER_URL, primaryViewUrl);
+        return getNonNullStringOrDefaultForNull(jsonObject, SERVER_URL, primaryViewUrl);
     }
 
     @NotNull
@@ -532,5 +531,14 @@ public class JenkinsJsonParser implements JenkinsParser {
     private @Nullable String getStringOrDefaultForNull(JsonObject jsonObject, @NotNull String key,
                                                        @Nullable String defaultValue) {
         return Optional.ofNullable(jsonObject.getStringOrDefault(createJsonKey(key, defaultValue))).orElse(defaultValue);
+    }
+
+    private @NotNull String getNonNullStringOrDefaultForNull(JsonObject jsonObject, @NotNull String key,
+                                                       @NotNull String defaultValue) {
+        return getStringOrDefaultForNull(jsonObject, key, defaultValue);
+    }
+
+    private @NotNull String getStringNonNull(JsonObject jsonObject, @NotNull String key) {
+        return Optional.ofNullable(jsonObject.getString(createJsonKey(key))).orElse(StringUtils.EMPTY);
     }
 }

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/UrlBuilder.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/UrlBuilder.java
@@ -20,6 +20,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.UriUtil;
+import com.intellij.util.io.URLUtil;
 import lombok.SneakyThrows;
 import org.codinjutsu.tools.jenkins.JenkinsAppSettings;
 import org.jetbrains.annotations.NotNull;
@@ -88,7 +89,9 @@ public class UrlBuilder {
                 LOG.debug(e.getMessage(), e);
             }
             //return com.intellij.util.io.URLUtil.encodeQuery(query);
-            return path + '?' + query;
+            return path + '?' + URLUtil.encodeURIComponent(query)
+                    .replaceAll("%3D", "=")
+                    .replaceAll("%2C", ",");
         }
     }
 

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/UrlBuilder.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/UrlBuilder.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.UriUtil;
 import lombok.SneakyThrows;
 import org.codinjutsu.tools.jenkins.JenkinsAppSettings;
-import org.codinjutsu.tools.jenkins.view.action.UploadPatchToJobAction;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -34,7 +33,7 @@ import java.util.Optional;
 
 public class UrlBuilder {
 
-    private static final Logger LOG = Logger.getInstance(UploadPatchToJobAction.class.getName());
+    private static final Logger LOG = Logger.getInstance(UrlBuilder.class.getName());
 
     private static final String API_JSON = "/api/json";
     private static final String BUILD = "/build";

--- a/src/main/java/org/codinjutsu/tools/jenkins/logic/UrlBuilder.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/logic/UrlBuilder.java
@@ -18,6 +18,8 @@ package org.codinjutsu.tools.jenkins.logic;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.util.UriUtil;
 import lombok.SneakyThrows;
 import org.codinjutsu.tools.jenkins.JenkinsAppSettings;
 import org.codinjutsu.tools.jenkins.view.action.UploadPatchToJobAction;
@@ -68,13 +70,7 @@ public class UrlBuilder {
     }
 
     public URL createRunJobUrl(String jobBuildUrl, JenkinsAppSettings configuration) {
-        try {
-            String s = jobBuildUrl + encodePathQuery(String.format("%s?delay=%dsec", BUILD, configuration.getBuildDelay()));
-            return new URL(s);
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(jobBuildUrl, encodePathQuery(String.format("%s?delay=%dsec", BUILD, configuration.getBuildDelay())));
     }
 
     @SneakyThrows
@@ -109,21 +105,12 @@ public class UrlBuilder {
     }
 
     public URL createStopBuildUrl(String buildUrl) {
-        try {//http://jenkins.internal/job/it4em-it4em-DPD-GEOR-UAT-RO/27/stop
-            return new URL(buildUrl + encodePath("stop"));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        //http://jenkins.internal/job/it4em-it4em-DPD-GEOR-UAT-RO/27/stop
+        return buildUrl(buildUrl, encodePath("stop"));
     }
 
     public URL createJenkinsWorkspaceUrl(JenkinsAppSettings configuration) {
-        try {
-            return new URL(encodePathQuery(configuration.getServerUrl() + API_JSON + TREE_PARAM + BASIC_JENKINS_INFO));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(configuration.getServerUrl(), encodePathQuery(API_JSON + TREE_PARAM + BASIC_JENKINS_INFO));
     }
 
     public URL createViewUrl(JenkinsPlateform jenkinsPlateform, String viewUrl) {
@@ -131,58 +118,27 @@ public class UrlBuilder {
         if (JenkinsPlateform.CLOUDBEES.equals(jenkinsPlateform)) {
             basicViewInfo = CLOUDBEES_VIEW_INFO;
         }
-        try {
-            return new URL(viewUrl + encodePathQuery(API_JSON + TREE_PARAM + basicViewInfo));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-
-        return null;
+        return buildUrl(viewUrl, encodePathQuery(API_JSON + TREE_PARAM + basicViewInfo));
     }
 
     public URL createJobUrl(String jobUrl) {
-        try {
-            return new URL(jobUrl + encodePathQuery(API_JSON + TREE_PARAM + BASIC_JOB_INFO));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(jobUrl, encodePathQuery(API_JSON + TREE_PARAM + BASIC_JOB_INFO));
     }
 
     public URL createBuildUrl(String buildUrl) {
-        try {
-            return new URL(buildUrl + encodePathQuery(API_JSON + TREE_PARAM + BASIC_BUILD_INFO));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(buildUrl, encodePathQuery(API_JSON + TREE_PARAM + BASIC_BUILD_INFO));
     }
 
     public URL createBuildsUrl(String buildUrl) {
-        try {
-            return new URL(buildUrl + encodePathQuery(API_JSON + TREE_PARAM + BASIC_BUILDS_INFO));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(buildUrl, encodePathQuery(API_JSON + TREE_PARAM + BASIC_BUILDS_INFO));
     }
 
     public URL createRssLatestUrl(String serverUrl) {
-        try {
-            return new URL(serverUrl + RSS_LATEST);
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(serverUrl, RSS_LATEST);
     }
 
     public URL createAuthenticationUrl(String serverUrl) {
-        try {
-            return new URL(serverUrl + encodePathQuery(API_JSON + TEST_CONNECTION_REQUEST));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-        return null;
+        return buildUrl(serverUrl, encodePathQuery(API_JSON + TEST_CONNECTION_REQUEST));
     }
 
     public URI createServerUrl(String serverUrl) {
@@ -195,6 +151,7 @@ public class UrlBuilder {
     }
 
     private void handleException(Exception ex) {
+        LOG.debug(ex);
         if (ex instanceof MalformedURLException) {
             throw new IllegalArgumentException("URL is malformed", ex);
         }
@@ -204,19 +161,13 @@ public class UrlBuilder {
     }
 
     public URL createNestedJobUrl(String currentJobUrl) {
-        try {
-            return new URL(currentJobUrl + encodePathQuery(API_JSON + TREE_PARAM + NESTED_JOBS_INFO));
-        } catch (Exception ex) {
-            handleException(ex);
-        }
-
-        return null;
+        return buildUrl(currentJobUrl, encodePathQuery(API_JSON + TREE_PARAM + NESTED_JOBS_INFO));
     }
 
     @NotNull
     public URL createComputerUrl(String serverUrl) {
         try {
-            return new URL(serverUrl + encodePathQuery(COMPUTER + API_JSON + TREE_PARAM +
+            return buildUrlNotNull(serverUrl, encodePathQuery(COMPUTER + API_JSON + TREE_PARAM +
                     COMPUTER_INFO));
         } catch (Exception ex) {
             handleException(ex);
@@ -227,7 +178,7 @@ public class UrlBuilder {
     @NotNull
     public URL createConfigureUrl(@NotNull String serverUrl) {
         try {
-            return new URL(removeTrailingSlash(serverUrl) + "/configure");
+            return buildUrlNotNull(removeTrailingSlash(serverUrl), "/configure");
         } catch (Exception ex) {
             handleException(ex);
             throw new IllegalArgumentException(ERROR_DURING_URL_CREATION, ex);
@@ -256,11 +207,21 @@ public class UrlBuilder {
     }
 
     public URL createFillValueItemsUrl(String jobUrl, String className, String param) {
+        return buildUrl(jobUrl, encodePathQuery(String.format(FILL_VALUE_ITEMS, className, param)));
+    }
+
+    private @Nullable URL buildUrl(String context, String pathWithQuery) {
         try {
-            return new URL(jobUrl +  encodePathQuery(String.format(FILL_VALUE_ITEMS, className, param)));
+            return buildUrlNotNull(context, pathWithQuery);
         } catch (Exception ex) {
             handleException(ex);
         }
         return null;
+    }
+
+    private @NotNull URL buildUrlNotNull(String context, @NotNull String pathWithQuery) throws MalformedURLException {
+        final boolean pathWithLeadingSlash = StringUtil.startsWithChar(pathWithQuery, '/');
+        final String serverContext = pathWithLeadingSlash ? UriUtil.trimTrailingSlashes(context) : pathWithQuery;
+        return new URL(serverContext + pathWithQuery);
     }
 }

--- a/src/main/java/org/codinjutsu/tools/jenkins/security/BasicSecurityClient.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/security/BasicSecurityClient.java
@@ -16,6 +16,7 @@
 
 package org.codinjutsu.tools.jenkins.security;
 
+import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpStatus;
@@ -31,6 +32,8 @@ import java.util.Collections;
 
 
 class BasicSecurityClient extends DefaultSecurityClient {
+
+    private static final Logger LOG = Logger.getInstance(BasicSecurityClient.class);
 
     private final String username;
     private String password = null;
@@ -61,6 +64,8 @@ class BasicSecurityClient extends DefaultSecurityClient {
             final var response = executeHttp(post);
             final var responseCode = response.getStatusLine().getStatusCode();
             final var responseBody = EntityUtils.toString(response.getEntity());
+            LOG.trace(String.format("Call url '%s' --> Status: %s, Data %s", jenkinsUrl, responseCode,
+                    responseBody));
             if (responseCode != HttpStatus.SC_OK) {
                 checkResponse(responseCode, responseBody);
             }

--- a/src/main/java/org/codinjutsu/tools/jenkins/security/DefaultSecurityClient.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/security/DefaultSecurityClient.java
@@ -238,6 +238,10 @@ class DefaultSecurityClient implements SecurityClient {
             throw new AuthenticationException("Not found", responseBody);
         }
 
+        if (HttpURLConnection.HTTP_BAD_REQUEST == statusCode) {
+            throw new AuthenticationException("Invalid Request", responseBody);
+        }
+
         if (statusCode == HttpURLConnection.HTTP_FORBIDDEN || statusCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
             if (StringUtils.containsIgnoreCase(responseBody, BAD_CRUMB_DATA)) {
                 throw new AuthenticationException("CSRF enabled -> Missing or bad crumb data", responseBody);

--- a/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.java
+++ b/src/main/java/org/codinjutsu/tools/jenkins/view/ConfigurationPanel.java
@@ -169,6 +169,9 @@ public class ConfigurationPanel {
 
             final String jenkinsUrl = RequestManager.getInstance(project).testAuthenticate(serverUrl.getText(),
                     username.getText(), password, crumbDataField.getText(), version, getConnectionTimeout());
+            if (StringUtils.isEmpty(jenkinsUrl)) {
+                throw new ConfigurationException("Cannot find 'Jenkins URL'. Please check your Jenkins Location");
+            }
             final ConfigurationValidator.ValidationResult validationResult = ConfigurationValidator.getInstance(project)
                     .validate(serverUrl.getText(), jenkinsUrl);
             if (validationResult.isValid()) {

--- a/src/test/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParserTest.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/logic/JenkinsJsonParserTest.java
@@ -225,6 +225,25 @@ public class JenkinsJsonParserTest {
     }
 
     @Test
+    public void getServerUrlForNullUrl() {
+        final String serverUrl = jsonParser.getServerUrl("{\"_class\":\"hudson.model.Hudson\"," +
+                "\"nodeName\":\"\"," +
+                "\"description\":\"Sample\"," +
+                "\"url\":null}");
+        assertThat(serverUrl).isEqualTo("");
+    }
+
+    @Test
+    public void getServerUrlForNullUrlAndPrimaryView() {
+        final String serverUrl = jsonParser.getServerUrl("{\"_class\":\"hudson.model.Hudson\"," +
+                "\"nodeName\":\"\"," +
+                "\"description\":\"Sample\"," +
+                "\"primaryView\":{\"_class\":\"hudson.model.AllView\",\"name\":\"all\",\"url\":\"http://localhost:8080/jenkins/view\"}," +
+                "\"url\":null}");
+        assertThat(serverUrl).isEqualTo("http://localhost:8080/jenkins/view");
+    }
+
+    @Test
     public void testLoadJob() throws Exception {
         Job actualJob = jsonParser.createJob(IOUtils.toString(getClass().getResourceAsStream("JsonRequestManager_loadJob.json")));
         final Job expectedJob = new JobBuilder()

--- a/src/test/java/org/codinjutsu/tools/jenkins/logic/UrlBuilderTest.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/logic/UrlBuilderTest.java
@@ -78,6 +78,12 @@ public class UrlBuilderTest {
     }
 
     @Test
+    public void createAuthenticationJSONUrlWithTrailingSlash() {
+        URL url = urlBuilder.createAuthenticationUrl("http://localhost:8080/jenkins/");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=nodeName,url,description,primaryView[name,url]");
+    }
+
+    @Test
     public void createComputerJSONUrl() {
         URL url = urlBuilder.createComputerUrl("http://localhost:8080/jenkins");
         assertThat(url).hasToString("http://localhost:8080/jenkins/computer/api/json?tree=computer[displayName,description,offline,assignedLabels[name]]");

--- a/src/test/java/org/codinjutsu/tools/jenkins/logic/UrlBuilderTest.java
+++ b/src/test/java/org/codinjutsu/tools/jenkins/logic/UrlBuilderTest.java
@@ -43,26 +43,26 @@ public class UrlBuilderTest {
         configuration.setServerUrl("http://localhost:8080/jenkins");
 
         URL url = urlBuilder.createJenkinsWorkspaceUrl(configuration);
-        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=url,description,nodeName,nodeDescription,primaryView[name,url],views[name,url,views[name,url]]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=url,description,nodeName,nodeDescription,primaryView%5Bname,url%5D,views%5Bname,url,views%5Bname,url%5D%5D");
     }
 
     @Test
     public void createViewUrlForClassicPlateform() {
         URL url = urlBuilder.createViewUrl(JenkinsPlateform.CLASSIC, "http://localhost:8080/jenkins/My%20View");
-        assertThat(url).hasToString("http://localhost:8080/jenkins/My%20View/api/json?tree=name,url,jobs[name,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport[description,iconUrl],lastBuild[url,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions[parameters[name,value]]],lastFailedBuild[url],lastSuccessfulBuild[url],property[parameterDefinitions[name,type,defaultParameterValue[value],description,choices]]]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/My%20View/api/json?tree=name,url,jobs%5Bname,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport%5Bdescription,iconUrl%5D,lastBuild%5Burl,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions%5Bparameters%5Bname,value%5D%5D%5D,lastFailedBuild%5Burl%5D,lastSuccessfulBuild%5Burl%5D,property%5BparameterDefinitions%5Bname,type,defaultParameterValue%5Bvalue%5D,description,choices%5D%5D%5D");
     }
 
     @Test
     public void createJobJSONUrl() {
         URL url = urlBuilder.createJobUrl("http://localhost:8080/jenkins/my%20Job");
-        assertThat(url).hasToString("http://localhost:8080/jenkins/my%20Job/api/json?tree=name,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport[description,iconUrl],lastBuild[url,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions[parameters[name,value]]],lastFailedBuild[url],lastSuccessfulBuild[url],property[parameterDefinitions[name,type,defaultParameterValue[value],description,choices]]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/my%20Job/api/json?tree=name,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport%5Bdescription,iconUrl%5D,lastBuild%5Burl,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions%5Bparameters%5Bname,value%5D%5D%5D,lastFailedBuild%5Burl%5D,lastSuccessfulBuild%5Burl%5D,property%5BparameterDefinitions%5Bname,type,defaultParameterValue%5Bvalue%5D,description,choices%5D%5D");
     }
 
     @Test
     public void createViewUrlForCloudbeesPlateform() {
         URL url = urlBuilder.createViewUrl(JenkinsPlateform.CLOUDBEES, "http://localhost:8080/jenkins/My%20View");
-        assertThat(url).hasToString("http://localhost:8080/jenkins/My%20View/api/json?tree=name,url,views[jobs[name,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport[description,iconUrl],lastBuild[url,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions[parameters[name,value]]],lastFailedBuild[url],lastSuccessfulBuild[url],property[parameterDefinitions[name,type,defaultParameterValue[value],description,choices]]]]");
-        assertThat(url.toString()).contains("/api/json?tree=name,url,views[jobs[name,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport[description,iconUrl],lastBuild[url,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions[parameters[name,value]]],lastFailedBuild[url],lastSuccessfulBuild[url],property[parameterDefinitions[name,type,defaultParameterValue[value],description,choices]]]]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/My%20View/api/json?tree=name,url,views%5Bjobs%5Bname,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport%5Bdescription,iconUrl%5D,lastBuild%5Burl,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions%5Bparameters%5Bname,value%5D%5D%5D,lastFailedBuild%5Burl%5D,lastSuccessfulBuild%5Burl%5D,property%5BparameterDefinitions%5Bname,type,defaultParameterValue%5Bvalue%5D,description,choices%5D%5D%5D%5D");
+        assertThat(url.toString()).contains("/api/json?tree=name,url,views%5Bjobs%5Bname,fullName,displayName,fullDisplayName,jobs,url,color,buildable,inQueue,healthReport%5Bdescription,iconUrl%5D,lastBuild%5Burl,id,building,result,number,displayName,fullDisplayName,timestamp,duration,actions%5Bparameters%5Bname,value%5D%5D%5D,lastFailedBuild%5Burl%5D,lastSuccessfulBuild%5Burl%5D,property%5BparameterDefinitions%5Bname,type,defaultParameterValue%5Bvalue%5D,description,choices%5D%5D%5D%5D");
     }
 
     @Test
@@ -74,19 +74,19 @@ public class UrlBuilderTest {
     @Test
     public void createAuthenticationJSONUrl() {
         URL url = urlBuilder.createAuthenticationUrl("http://localhost:8080/jenkins");
-        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=nodeName,url,description,primaryView[name,url]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=nodeName,url,description,primaryView%5Bname,url%5D");
     }
 
     @Test
     public void createAuthenticationJSONUrlWithTrailingSlash() {
         URL url = urlBuilder.createAuthenticationUrl("http://localhost:8080/jenkins/");
-        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=nodeName,url,description,primaryView[name,url]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/api/json?tree=nodeName,url,description,primaryView%5Bname,url%5D");
     }
 
     @Test
     public void createComputerJSONUrl() {
         URL url = urlBuilder.createComputerUrl("http://localhost:8080/jenkins");
-        assertThat(url).hasToString("http://localhost:8080/jenkins/computer/api/json?tree=computer[displayName,description,offline,assignedLabels[name]]");
+        assertThat(url).hasToString("http://localhost:8080/jenkins/computer/api/json?tree=computer%5BdisplayName,description,offline,assignedLabels%5Bname%5D%5D");
     }
 
     @Before


### PR DESCRIPTION
- use correct default values
- fix wrong encode query parameters (for RFC 7230 and RFC 3986) 

closes #426 